### PR TITLE
Add elastic index name to MappingEvent

### DIFF
--- a/src/Event/MappingEvent.php
+++ b/src/Event/MappingEvent.php
@@ -7,10 +7,12 @@ use Symfony\Component\EventDispatcher\Event;
 class MappingEvent extends Event
 {
     protected $mapping;
+    protected $index;
 
-    public function __construct(array $mapping)
+    public function __construct(array $mapping, $index)
     {
         $this->mapping = $mapping;
+        $this->index = $index;
     }
 
     public function getMapping()
@@ -21,5 +23,10 @@ class MappingEvent extends Event
     public function setMapping($mapping)
     {
         $this->mapping = $mapping;
+    }
+
+    public function getIndex()
+    {
+        return $this->index;
     }
 }

--- a/src/Service/Api.php
+++ b/src/Service/Api.php
@@ -67,7 +67,7 @@ class Api extends BaseApi
             throw new \RuntimeException('Could not fetch base mapping');
         }
 
-        $ev = new MappingEvent($m);
+        $ev = new MappingEvent($m, $this->index);
         $this->dispatcher->dispatch(WmsearchEvents::MAPPING, $ev);
 
         return $this->baseMapping = $ev->getMapping();


### PR DESCRIPTION
So you can listen for the event and set a mapping based on the index name.

In case the index is **page** I don't want to alter the default mapping, but if it's something else I do want to define my own mapping.

```yml
// module.services.yml
services:
  module.search.index.jobs:
    class: Drupal\wmsearch\Service\Api
    arguments:
      - '@app.root'
      - '@event_dispatcher'
      - '@module_handler'
      - '%wmsearch.elastic.endpoint%'
      - '%module.search.index.jobs%' <-- is set to "jobs"
```

```php
<?php

namespace Drupal\module\EventSubscriber\Form;

use Drupal\wmsearch\Event\MappingEvent;
use Drupal\wmsearch\WmsearchEvents;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;

class MappingSubscriber implements EventSubscriberInterface
{

    private $assetsDirectory;

    public function __construct($assetsDirectory)
    {
        $this->assetsDirectory = $assetsDirectory;
    }

    public static function getSubscribedEvents()
    {
        return [
            WmsearchEvents::MAPPING => 'alterMapping'
        ];
    }

    public function alterMapping(MappingEvent $event)
    {
        switch ($event->getIndex()) {
            case 'jobs':
                $event->setMapping($this->loadMapping('jobs.json'));
                break;
            // ...
        }
    }

    private function loadMapping($filename)
    {
        $file = $this->assetsDirectory . DIRECTORY_SEPARATOR . $filename;

        $mapping = json_decode(file_get_contents($file), true);

        if (!$mapping) {
            throw new \RuntimeException(
                sprintf('Could not find mapping "%s"', $file)
            );
        }

        return $mapping;
    }
}
```