### PR TITLE
Allow cross type queries

### DIFF
--- a/src/Entity/Query/PageQuery.php
+++ b/src/Entity/Query/PageQuery.php
@@ -8,7 +8,7 @@ class PageQuery extends Query
 {
     public function __construct(array $query = [])
     {
-        parent::__construct('page', $query);
+        parent::__construct($query, 'page');
     }
 
     public function complete($query, $fuzzy = 0)

--- a/src/Entity/Query/Query.php
+++ b/src/Entity/Query/Query.php
@@ -7,7 +7,7 @@ class Query implements QueryInterface, HighlightInterface
     protected $query;
     protected $docType;
 
-    public function __construct($docType, array $query = [])
+    public function __construct(array $query = [], $docType = '')
     {
         $this->docType = $docType;
         $this->query = $query;

--- a/src/Service/BaseApi.php
+++ b/src/Service/BaseApi.php
@@ -221,19 +221,21 @@ class BaseApi
 
     protected function execQuery(QueryInterface $query)
     {
-        $docType = $query->getDocumentType();
-        if (!$docType) {
-            throw new \InvalidArgumentException(
-                'Query doesn\'t specify a document type'
+        $ep = sprintf(
+            '%s/_search',
+            $this->index
+        );
+
+        if ($docType = $query->getDocumentType()) {
+            $ep = sprintf(
+                '%s/%s/_search',
+                $this->index,
+                $docType
             );
         }
 
         return $this->post(
-            sprintf(
-                '%s/%s/_search',
-                $this->index,
-                $query->getDocumentType()
-            ),
+            $ep,
             $query->toArray()
         );
     }


### PR DESCRIPTION
I have the types **job** and **article** with facets.

Elastic has a useful [more_like_this](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/query-dsl-mlt-query.html) query that allows me to quicky get relevant articles for another entity ( in this case a **job** )

However; these type of queries [can't point to the `/<index>/<type>/_search` endpoint](https://stackoverflow.com/questions/28590409/elasticsearch-more-like-this-query-on-multiple-index-types), but rather `/<index>/_search`.

---

This MR removes the `InvalidArgumentException('Query doesn\'t specify a document type')` exception. When a Query doesn't specify a document type, we call `_search` on the index.

```json
POST /<index>/_search
{
   "query":{
      "bool":{
         "must" : {
            "more_like_this" : {
               "fields" : ["facets.key"],
               "like" : [
                 {
                   "_id" : "node:nl:5",
                   "_type" : "job"
                 }
               ],
               "min_term_freq" : 1,
               "min_doc_freq": 1
            }
         },
         "filter": [
            {
               "term": {
                  "language": "nl"
               }
            },
            {
               "term": {
                  "_type": "article"
               }
            }
        ]
      }
   }
}
```