### PR TITLE
Improve memory pressure when queuing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2024-01-08
+### Added
+- Improve memory pressure when queueing large amounts of items
+
+## [0.12.0] - 2023-09-12
 ### Added
 - Add Drupal 10 compatibility
 

--- a/src/Service/Batch/QueueBatch.php
+++ b/src/Service/Batch/QueueBatch.php
@@ -102,6 +102,9 @@ class QueueBatch
         foreach ($storage->loadMultiple($ids) as $entity) {
             wmsearch_queue($entity, true);
         }
+
+        $this->memoryCache->deleteAll();
+        gc_collect_cycles();
     }
 
     public function finish(bool $success, array $results): void


### PR DESCRIPTION
The batch API already does its best to keep the process alive by keeping track of the memory usage.
But we can help it a bit by clearing the memory cache and triggering the garbage collector.

This is especially useful when you're dealing with a lot of entities.