### PR TITLE
Make search API raw error message human-readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.2] - 2024-02-13
+### Added
+- Make search API raw error message human-readable
+
 ## [0.12.1] - 2024-01-08
 ### Added
 - Improve memory pressure when queueing large amounts of items

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -42,9 +42,59 @@ class ApiException extends \RuntimeException
         );
     }
 
+    public function hasBody()
+    {
+        return null !== $this->body;
+    }
+
+    /**
+     * @example Body of a failed API request:
+     *  Elastic api request failed: {
+     *    "error": {
+     *      "root_cause": [
+     *        {
+     *          "type": "parsing_exception",
+     *          "reason": "No value specified for terms query",
+     *          "line": 1,
+     *          "col": 79
+     *        }
+     *      ],
+     *      "type": "x_content_parse_exception",
+     *      "reason": "[1:79] [bool] failed to parse field [filter]",
+     *      "caused_by": {
+     *        "type": "parsing_exception",
+     *        "reason": "No value specified for terms query",
+     *        "line": 1,
+     *        "col": 79
+     *      }
+     *    },
+     *    "status": 400
+     *  }
+    */
     public function getBody()
     {
         return $this->body;
+    }
+
+    public function getReason()
+    {
+        if ($this->hasBody()) {
+            $reason = $this->getBody()['error']['root_cause'][0]['reason']
+                ?? $this->getBody()['error']['reason']
+                ?? null
+            ;
+        }
+
+        return $reason ?? $this->getMessage();
+    }
+
+    public function getStatus()
+    {
+        if ($this->hasBody()) {
+            $status = $this->getBody()['status'] ?? null;
+        }
+
+        return $status ?? ($this->getCode() ?: 400);
     }
 
     public function is($type)

--- a/src/Service/ResultFormatter.php
+++ b/src/Service/ResultFormatter.php
@@ -88,8 +88,18 @@ class ResultFormatter implements ResultFormatterInterface
 
     public function formatException(ApiException $e = null)
     {
+        if (null === $e) {
+            return [
+                'err' => 'Something went wrong',
+                'status' => 400,
+            ];
+        }
+
         // TODO expose all errors or use a SafeToPrintException...?
-        return ['err' => $e ? $e->getMessage() : 'Something went wrong'];
+        return [
+            'err' => $e->getReason(),
+            'status' => $e->getStatus(),
+        ];
     }
 }
 


### PR DESCRIPTION
If the API error message is a raw error body message, we will display the error reason, otherwise we will simply the error message as usual.

cf. https://github.com/wieni/www.dnsbelgium.be/issues/106

<details><summary>BEFORE</summary>
<p>

https://www.dnsbelgium.be/search/json?q=quoi

```json
{
  "err": "Elastic api request failed: {
    \"error\": {
        \"root_cause\": [
            {
                \"type\": \"parsing_exception\",
                \"reason\": \"No value specified for terms query\",
                \"line\": 1,
                \"col\": 79
            }
        ],
        \"type\": \"x_content_parse_exception\",
        \"reason\": \"[1:79] [bool] failed to parse field [filter]\",
        \"caused_by\": {
            \"type\": \"parsing_exception\",
            \"reason\": \"No value specified for terms query\",
            \"line\": 1,
            \"col\": 79
        }
    },
    \"status\": 400
}"
}
```

</p>
</details> 

<details><summary>AFTER</summary>
<p>

https://dnsbelgium.wieni.site/search/json?q=quoi

```json
{
  "err": "No value specified for terms query",
  "status": 400
}
```

</p>
</details> 